### PR TITLE
Change #9700be to #8662fc

### DIFF
--- a/themes/color-theme-sweet.json
+++ b/themes/color-theme-sweet.json
@@ -12,7 +12,7 @@
     "textBlockQuote.border": "#222235",
     "textCodeBlock.background": "#222235",
     "textLink.activeForeground": "#ffffff",
-    "textLink.foreground": "#9700be",
+    "textLink.foreground": "#8662fc",
     "textPreformat.foreground": "#ffffff",
     "textSeparator.foreground": "#3F3F54",
     "button.background": "#222235",


### PR DESCRIPTION
I changed the color #9700be to #8662fc because of the fact that if your environment is a little bright its getting really hard to see the color #9700be which was assigned to eg. the file names, strings, workspace name, etc. and by replacing it with #8662fc its way easier and still matched the theme.
